### PR TITLE
Use an idle callback instead of leisure

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,4 +1,5 @@
 const Meta = imports.gi.Meta;
+const GLib = imports.gi.GLib;
 
 /* This has been tested with dynamic workspaces. It works well with dynamic workspaces, 
  * but can work well  with static if you have
@@ -82,7 +83,7 @@ const _display_handles = [];
 
 function enable() {
   _display_handles.push(global.display.connect('window-created', (_, win) => {
-    global.run_at_leisure(checkFullScreen.bind(this, win));
+    GLib.idle_add(GLib.PRIORITY_IDLE, checkFullScreen.bind(this, win));
   }));
   _window_manager_handles.push(global.window_manager.connect('size-change', (_, act, change) => {
     if (change === Meta.SizeChange.MAXIMIZE)

--- a/extension.js
+++ b/extension.js
@@ -83,7 +83,7 @@ const _display_handles = [];
 
 function enable() {
   _display_handles.push(global.display.connect('window-created', (_, win) => {
-    GLib.idle_add(GLib.PRIORITY_IDLE, checkFullScreen.bind(this, win));
+    GLib.idle_add(GLib.PRIORITY_LOW, checkFullScreen.bind(this, win));
   }));
   _window_manager_handles.push(global.window_manager.connect('size-change', (_, act, change) => {
     if (change === Meta.SizeChange.MAXIMIZE)


### PR DESCRIPTION
run_at_leisure() is not a standard function for deferring callbacks and
may cause unforseen problems.

Replace it's usage with GLib.idle_add().